### PR TITLE
[PRD-3621] Fixed escaping of number sign `#` on properties files

### DIFF
--- a/src/main/java/org/osjava/sj/loader/util/CustomProperties.java
+++ b/src/main/java/org/osjava/sj/loader/util/CustomProperties.java
@@ -36,47 +36,16 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.util.Properties;
 
 
 public class CustomProperties extends AbstractProperties {
 
     public synchronized void load(InputStream in) throws IOException {
-        try {
-            BufferedReader reader = new BufferedReader( new InputStreamReader(in) );
-            String line = "";
-            String nextLine = null;
-            while( (line = reader.readLine()) != null) {
-
-                // we may already be on a multi-line statement.
-                if(nextLine != null) {
-                    line = nextLine + line;
-                    nextLine = null;
-                }
-
-                line = line.trim();
-                if(line.endsWith("\\")) {
-                    nextLine = line;
-                    continue;
-                }
-
-                int idx = line.indexOf('#');
-                // remove comment
-                if(idx != -1) {
-                    line = line.substring(0,idx);
-                }
-                // split equals sign
-                idx = line.indexOf('=');
-                if(idx != -1) {
-                    this.setProperty(line.substring(0,idx), line.substring(idx+1));
-                } else {
-                    // blank line, or just a bad line
-                    // we ignore it
-                }
-            }
-            reader.close();
-        } catch(IOException ioe) {
-            ioe.printStackTrace();
-        }
+        Properties p = new Properties();
+        p.load(in);
+		in.close();
+		this.putAll(p);
     }
 
 }


### PR DESCRIPTION
Removed a static lookup for '#' on the line in favor of parsing the file with `java.util.Properties`.
- https://github.com/pentaho/pentaho-simple-jndi/issues/3
- https://jira.pentaho.com/browse/PRD-3621
- https://code.google.com/archive/p/osjava/issues/4
- https://forums.pentaho.com/threads/81216-jdbc-properties-escape-character/